### PR TITLE
test(runtime): add 20 comprehensive layout tests

### DIFF
--- a/crates/w3cos-runtime/src/layout.rs
+++ b/crates/w3cos-runtime/src/layout.rs
@@ -226,3 +226,163 @@ fn to_taffy_overflow(o: WOverflow) -> taffy::Overflow {
         WOverflow::Auto => taffy::Overflow::Scroll,
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use w3cos_std::component::Component;
+    use w3cos_std::style::{Dimension as WDim, Display as WDisp, FlexDirection as WDir, Style};
+
+    fn s() -> Style { Style::default() }
+
+    fn col() -> Style {
+        Style { display: WDisp::Flex, flex_direction: WDir::Column, gap: 10.0,
+            padding: w3cos_std::style::Edges::all(16.0),
+            width: WDim::Px(400.0), height: WDim::Px(600.0), ..Style::default() }
+    }
+
+    fn row() -> Style {
+        Style { display: WDisp::Flex, flex_direction: WDir::Row, gap: 8.0,
+            width: WDim::Px(400.0), height: WDim::Px(100.0), ..Style::default() }
+    }
+
+    #[test] fn single_node_has_size() {
+        let l = compute(&Component::text("Hi", s()), 800.0, 600.0).unwrap();
+        assert_eq!(l.len(), 1);
+        assert!(l[0].0.width > 0.0);
+    }
+
+    #[test] fn root_at_origin() {
+        let l = compute(&Component::text("R", s()), 800.0, 600.0).unwrap();
+        assert_eq!(l[0].0.x, 0.0);
+        assert_eq!(l[0].0.y, 0.0);
+    }
+
+    #[test] fn column_stacks_vertically() {
+        let l = compute(&Component::column(col(), vec![
+            Component::text("A", s()), Component::text("B", s()),
+        ]), 800.0, 600.0).unwrap();
+        assert_eq!(l.len(), 3);
+        assert!(l[2].0.y > l[1].0.y);
+    }
+
+    #[test] fn row_arranges_horizontally() {
+        let l = compute(&Component::row(row(), vec![
+            Component::text("A", s()), Component::text("B", s()),
+        ]), 800.0, 600.0).unwrap();
+        assert_eq!(l.len(), 3);
+        assert!(l[2].0.x > l[1].0.x);
+    }
+
+    #[test] fn padding_offsets_child() {
+        let l = compute(&Component::column(Style {
+            display: WDisp::Flex, padding: w3cos_std::style::Edges::all(40.0),
+            width: WDim::Px(400.0), height: WDim::Px(300.0), ..Style::default()
+        }, vec![Component::text("X", s())]), 800.0, 600.0).unwrap();
+        assert!(l[1].0.x >= 40.0);
+        assert!(l[1].0.y >= 40.0);
+    }
+
+    #[test] fn empty_container_one_entry() {
+        let l = compute(&Component::boxed(s(), vec![]), 800.0, 600.0).unwrap();
+        assert_eq!(l.len(), 1);
+    }
+
+    #[test] fn deeply_nested_11_nodes() {
+        let mut c = Component::text("D", s());
+        for _ in 0..10 { c = Component::column(col(), vec![c]); }
+        assert_eq!(compute(&c, 800.0, 600.0).unwrap().len(), 11);
+    }
+
+    #[test] fn button_has_minimum_size() {
+        let l = compute(&Component::button("OK", s()), 800.0, 600.0).unwrap();
+        assert!(l[0].0.width > 32.0);
+        assert!(l[0].0.height > 16.0);
+    }
+
+    #[test] fn three_row_children_ordered_ltr() {
+        let l = compute(&Component::row(
+            Style { display: WDisp::Flex, flex_direction: WDir::Row, gap: 24.0,
+                width: WDim::Px(600.0), height: WDim::Px(50.0), ..Style::default() },
+            vec![Component::text("X",s()), Component::text("Y",s()), Component::text("Z",s())],
+        ), 800.0, 600.0).unwrap();
+        assert_eq!(l.len(), 4);
+        assert!(l[1].0.x < l[2].0.x);
+        assert!(l[2].0.x < l[3].0.x);
+    }
+
+    #[test] fn gap_vs_no_gap() {
+        let ng = compute(&Component::column(
+            Style { display: WDisp::Flex, flex_direction: WDir::Column, width: WDim::Px(400.0), height: WDim::Px(300.0), ..Style::default() },
+            vec![Component::text("A",s()), Component::text("B",s())],
+        ), 800.0, 600.0).unwrap();
+        let wg = compute(&Component::column(
+            Style { display: WDisp::Flex, flex_direction: WDir::Column, gap: 20.0, width: WDim::Px(400.0), height: WDim::Px(300.0), ..Style::default() },
+            vec![Component::text("A",s()), Component::text("B",s())],
+        ), 800.0, 600.0).unwrap();
+        let d0 = ng[2].0.y - (ng[1].0.y + ng[1].0.height);
+        let d1 = wg[2].0.y - (wg[1].0.y + wg[1].0.height);
+        assert!(d1 >= d0);
+    }
+
+    #[test] fn mixed_text_button_children() {
+        let l = compute(&Component::column(col(), vec![
+            Component::text("T", s()), Component::button("B", s()),
+        ]), 800.0, 600.0).unwrap();
+        assert_eq!(l.len(), 3);
+    }
+
+    #[test] fn column_vs_row_axes_differ() {
+        let cl = compute(&Component::column(col(), vec![
+            Component::text("A",s()), Component::text("B",s()),
+        ]), 800.0, 600.0).unwrap();
+        let rl = compute(&Component::row(row(), vec![
+            Component::text("A",s()), Component::text("B",s()),
+        ]), 800.0, 600.0).unwrap();
+        assert!((cl[2].0.y - cl[1].0.y).abs() > (cl[2].0.x - cl[1].0.x).abs());
+        assert!((rl[2].0.x - rl[1].0.x).abs() > (rl[2].0.y - rl[1].0.y).abs());
+    }
+
+    #[test] fn zero_viewport() {
+        assert_eq!(compute(&Component::text("Z", s()), 0.0, 0.0).unwrap().len(), 1);
+    }
+
+    #[test] fn narrow_viewport() {
+        assert_eq!(compute(&Component::text("N", s()), 100.0, 100.0).unwrap().len(), 1);
+    }
+
+    #[test] fn rect_clone_debug() {
+        let r = LayoutRect { x: 1.0, y: 2.0, width: 3.0, height: 4.0 };
+        assert_eq!(r.x, r.clone().x);
+        assert!(format!("{:?}", r).contains("LayoutRect"));
+    }
+
+    #[test] fn single_child_inside_parent() {
+        let l = compute(&Component::column(col(), vec![Component::text("O", s())]), 800.0, 600.0).unwrap();
+        assert!(l[1].0.x >= l[0].0.x);
+        assert!(l[1].0.y >= l[0].0.y);
+    }
+
+    #[test] fn fixed_size_box_respected() {
+        let l = compute(&Component::boxed(
+            Style { width: WDim::Px(200.0), height: WDim::Px(100.0), ..Style::default() }, vec![],
+        ), 800.0, 600.0).unwrap();
+        assert!((l[0].0.width - 200.0).abs() < 2.0);
+        assert!((l[0].0.height - 100.0).abs() < 2.0);
+    }
+
+    #[test] fn five_children_column() {
+        let children: Vec<_> = (0..5).map(|i| Component::text(&i.to_string(), s())).collect();
+        assert_eq!(compute(&Component::column(col(), children), 800.0, 600.0).unwrap().len(), 6);
+    }
+
+    #[test] fn text_width_scales_with_length() {
+        let short = compute(&Component::text("A", s()), 800.0, 600.0).unwrap();
+        let long = compute(&Component::text("A very long text string", s()), 800.0, 600.0).unwrap();
+        assert!(long[0].0.width > short[0].0.width);
+    }
+
+    #[test] fn large_viewport() {
+        let l = compute(&Component::text("Big", s()), 4000.0, 3000.0).unwrap();
+        assert!(l[0].0.width > 0.0);
+    }
+}


### PR DESCRIPTION
Closes #22

## Summary
Adds 20 unit tests for `w3cos-runtime/src/layout.rs` covering all public layout computation functions.

### Test Coverage (20 tests)
| Category | Tests | Description |
|----------|-------|-------------|
| Basic layout | 4 | Single node, root offset, column/row stacking |
| Spacing | 3 | Padding offsets, gap comparison, mixed children |
| Edge cases | 5 | Empty container, deeply nested (10 levels), zero/narrow/large viewport |
| Component types | 3 | Button sizing, text width scaling, mixed text+button |
| Geometry | 2 | Fixed-size box accuracy, column vs row axes |
| Traits | 1 | LayoutRect Clone + Debug |
| Integration | 2 | 5-child column, single-child containment |

### Verification
- ✅ `cargo test -p w3cos-runtime`: **122 tests pass** (102 existing + 20 new)
- ✅ `cargo clippy`: No new warnings
- ✅ Zero failures, zero ignored

Co-authored-by: 小米粒 <openclaw@sjykj.dev>